### PR TITLE
Remove d3-module keyword.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "d3-twodim is a D3.v3.js module for creating two-dimensional representations of data for end-user exploration.",
   "keywords": [
     "d3",
-    "d3-module",
     "scatterplot",
     "scatter",
     "splatterplot",


### PR DESCRIPTION
I’d like the d3-module keyword to be used only for modules that use the D3 4.0 module pattern as documented in [Let’s Make a (D3) Plugin](https://bost.ocks.org/mike/d3-plugin/). This library is targeted at D3 3.x because it depends on the global `d3` and D3 3.x API’s such as d3.scale.category10. Would you mind removing the d3-module keyword, at least until this library is updated to support D3 4+?